### PR TITLE
Accept HTTP/1.0 responses

### DIFF
--- a/index.js
+++ b/index.js
@@ -41,7 +41,7 @@ class myAgent extends https.Agent {
       proxySocket.removeListener('error', errorListener)
       proxySocket.removeListener('data', dataListener)
 
-      const m = response.match(/^HTTP\/1.1 (\d*)/)
+      const m = response.match(/^HTTP\/1.\d (\d*)/)
       if (m == null || m[1] == null) {
         proxySocket.destroy()
         return cb(new Error(response.trim()))


### PR DESCRIPTION
All of the proxy servers I'm working with respond with 
```HTTP/1.0 200 Connection established```

whereas the current library expects `HTTP/1.1`