### PR TITLE
Updates to agent init, error handling, and test coverage

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "keepalive-proxy-agent",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -37,5 +37,5 @@
     "tunnel": "0.0.6",
     "tunnel-agent": "^0.6.0"
   },
-  "version": "1.3.0"
+  "version": "1.3.1"
 }


### PR DESCRIPTION
- Allow agent to also be configured with proxy uri string
- Allow agent to also be configured with json without the proxy: key (matches https-proxy-agent so becomes a drop in replacement for that)
- When error is thrown on CONNECT method failures, add Error code "ERR_HTTP_PROXY_CONNECT" so clients can handle these failures generically and explicitly
- Update test coverage with cases for the above features.